### PR TITLE
Use Ruby 2.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM ruby:2.4-alpine
+FROM ruby:2.3-alpine
 
 LABEL maintainer="Clearhaus"
 
 WORKDIR /opt/pedicel-pay
 COPY . /opt/pedicel-pay
-RUN bundle install
+RUN apk update && \
+    apk add make libc-dev gcc && \
+    bundle install --without development
 
 ENTRYPOINT ["/opt/pedicel-pay/exe/pedicel-pay"]


### PR DESCRIPTION
The builds have been failing since we went with Ruby 2.3 and the OpenSSL Gem. This fixes it.