### PR TITLE
Adjust sample cryptogram length

### DIFF
--- a/lib/pedicel-pay/token_data.rb
+++ b/lib/pedicel-pay/token_data.rb
@@ -93,7 +93,7 @@ module PedicelPay
       self.dm_id ||= Helper.bytestring_to_hex(PedicelPay.config[:random].bytes(5))
 
       # Cryptogram
-      self.cryptogram ||= Base64.strict_encode64(PedicelPay.config[:random].bytes(10))
+      self.cryptogram ||= Base64.strict_encode64(PedicelPay.config[:random].bytes(20))
 
       # ECI
       self.eci ||= %w[05 06 07].sample

--- a/lib/pedicel-pay/version.rb
+++ b/lib/pedicel-pay/version.rb
@@ -1,3 +1,3 @@
 module PedicelPay
-  VERSION = '0.0.4'
+  VERSION = '0.0.5'
 end


### PR DESCRIPTION
The 3-D Secure 1.0.2 protocol specification regarding `TX.cavv`:

> Contains a 20 byte value that has been Base64 encoded, giving a 28 byte result.