### PR TITLE
No alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
-FROM ruby:2.3
+FROM ruby:2.3-slim-stretch
 
 LABEL maintainer="Clearhaus"
 
 WORKDIR /opt/pedicel-pay
 COPY . /opt/pedicel-pay
-RUN bundle install --without development
+RUN apt-get update && \
+    apt-get install -y gcc libc-dev libssl-dev make && \
+    bundle install --without development && \
+    apt-get --purge remove -y gcc libc-dev libssl-dev make && \
+    apt-get --purge autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["/opt/pedicel-pay/exe/pedicel-pay"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
-FROM ruby:2.3-alpine
+FROM ruby:2.3
 
 LABEL maintainer="Clearhaus"
 
 WORKDIR /opt/pedicel-pay
 COPY . /opt/pedicel-pay
-RUN apk update && \
-    apk add make libc-dev gcc && \
-    bundle install --without development
+RUN bundle install --without development
 
 ENTRYPOINT ["/opt/pedicel-pay/exe/pedicel-pay"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,11 @@
-FROM ruby:2.3-slim-stretch
+FROM ruby:2.3.6-alpine
 
 LABEL maintainer="Clearhaus"
 
 WORKDIR /opt/pedicel-pay
 COPY . /opt/pedicel-pay
-RUN apt-get update && \
-    apt-get install -y gcc libc-dev libssl-dev make && \
-    bundle install --without development && \
-    apt-get --purge remove -y gcc libc-dev libssl-dev make && \
-    apt-get --purge autoremove -y && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk update && \
+    apk add make libc-dev gcc && \
+    bundle install --without development
 
 ENTRYPOINT ["/opt/pedicel-pay/exe/pedicel-pay"]

--- a/lib/pedicel-pay/backend.rb
+++ b/lib/pedicel-pay/backend.rb
@@ -109,7 +109,9 @@ module PedicelPay
         # https://wiki.openssl.org/index.php/Manual:PKCS7_verify(3)#VERIFY_PROCESS
         OpenSSL::PKCS7::NOCHAIN  | # Ignore certs in the message.
         OpenSSL::PKCS7::NOINTERN   # Only look at the supplied certificate.
-      unless signature.verify([certificate], OpenSSL::X509::Store.new, message, flags)
+      trust_store = OpenSSL::X509::Store.new
+      trust_store.add_cert(ca_certificate).add_cert(intermediate_certificate)
+      unless signature.verify([certificate], trust_store, message, flags)
         fail 'signature is wrong'
       end
 

--- a/lib/pedicel-pay/backend.rb
+++ b/lib/pedicel-pay/backend.rb
@@ -104,6 +104,15 @@ module PedicelPay
         OpenSSL::PKCS7::BINARY # Handle 0x00 correctly.
       )
 
+      # Check that the newly created signature is good.
+      flags = \
+        # https://wiki.openssl.org/index.php/Manual:PKCS7_verify(3)#VERIFY_PROCESS
+        OpenSSL::PKCS7::NOCHAIN  | # Ignore certs in the message.
+        OpenSSL::PKCS7::NOINTERN   # Only look at the supplied certificate.
+      unless signature.verify([certificate], OpenSSL::X509::Store.new, message, flags)
+        fail 'signature is wrong'
+      end
+
       if replace
         # Just replace token.signature.
       else


### PR DESCRIPTION
```shell
$ docker run --rm -it -v /tmp/x.rb:/x.rb ruby:2.3-alpine ruby /x.rb
false
$ docker run --rm -it -v /tmp/x.rb:/x.rb ruby:2.3 ruby /x.rb
true
```
where `x.rb` is this:
```ruby
#!/usr/bin/ruby

require 'openssl'

def ec_key_to_pkey_public_key(ec_key)
  # EC#public_key is not a PKey public key, but an EC point.
  pub = OpenSSL::PKey::EC.new(ec_key.group)
  pub.public_key = ec_key.is_a?(OpenSSL::PKey::PKey) ? ec_key.public_key : ec_key

  pub
end

if OpenSSL::PKey::EC.new.respond_to?(:private_key?) && !OpenSSL::PKey::EC.new.respond_to?(:private?)
  class OpenSSL::PKey::EC
    def private?
      private_key?
    end
  end
end


root_key = OpenSSL::PKey::EC.new("prime256v1")
root_key.generate_key
root_public = OpenSSL::PKey::EC.new('prime256v1')
root_public.public_key = root_key.public_key

leaf_key = OpenSSL::PKey::EC.new("prime256v1")
leaf_key.generate_key
leaf_public = OpenSSL::PKey::EC.new('prime256v1')
leaf_public.public_key = leaf_key.public_key

root = OpenSSL::X509::Certificate.new
root.version = 2 # cf. RFC 5280 - to make it a "v3" certificate
root.serial = 1
root.subject = OpenSSL::X509::Name.parse "/DC=org/DC=ruby-lang/CN=Ruby CA"
root.issuer = root.subject # root CA's are "self-signed"
root.public_key = ec_key_to_pkey_public_key(root_public)
root.not_before = Time.now
root.not_after = root.not_before + 2 * 365 * 24 * 60 * 60 # 2 years validity
ef = OpenSSL::X509::ExtensionFactory.new
ef.subject_certificate = root
ef.issuer_certificate = root
root.add_extension(ef.create_extension("basicConstraints","CA:TRUE",true))
root.add_extension(ef.create_extension("keyUsage","keyCertSign, cRLSign", true))
root.add_extension(ef.create_extension("subjectKeyIdentifier","hash",false))
root.add_extension(ef.create_extension("authorityKeyIdentifier","keyid:always",false))
root.sign(root_key, OpenSSL::Digest::SHA256.new)


leaf = OpenSSL::X509::Certificate.new
leaf.version = 2
leaf.serial = 2
leaf.subject = OpenSSL::X509::Name.parse "/DC=org/DC=ruby-lang/CN=Ruby certificate"
leaf.issuer = root.subject # root CA is the issuer
leaf.public_key = ec_key_to_pkey_public_key(leaf_public)
leaf.not_before = Time.now
leaf.not_after = leaf.not_before + 1 * 365 * 24 * 60 * 60 # 1 years validity
ef = OpenSSL::X509::ExtensionFactory.new
ef.subject_certificate = leaf
ef.issuer_certificate = root
leaf.add_extension(ef.create_extension("keyUsage","digitalSignature", true))
leaf.add_extension(ef.create_extension("subjectKeyIdentifier","hash",false))
leaf.sign(root_key, OpenSSL::Digest::SHA256.new)

message = 'random message'
sig = OpenSSL::PKCS7.sign(leaf, leaf_key, message)


store = OpenSSL::X509::Store.new
store.add_cert root
puts sig.verify([leaf], store, message)
```