### PR TITLE
Add command to extract the symmetric key

### DIFF
--- a/exe/pedicel-pay
+++ b/exe/pedicel-pay
@@ -147,7 +147,7 @@ module PedicelPay
 
       client = Helper.load_client(options['client-path'])
 
-      puts client.symmetric_key(token, certificate: client.certificate)
+      puts client.symmetric_key(token)
     end
 
 

--- a/exe/pedicel-pay
+++ b/exe/pedicel-pay
@@ -137,6 +137,19 @@ module PedicelPay
       puts token.to_json
     end
 
+    desc 'extract-symmetric-key', 'Extract the symmetric key that is used for encryption/decryption of the token'
+    option 'client-path', type: :string, path: true, aliases: :c
+    option 'file', type: :string, aliases: :f
+
+    def extract_symmetric_key
+      raw_token = options['file'] ? File.read(options['file']) : $stdin.read
+      token = JSON.parse(raw_token)
+
+      client = Helper.load_client(options['client-path'])
+
+      puts client.symmetric_key(token, certificate: client.certificate)
+    end
+
 
     desc 'decrypt-token', 'Decrypt a token'
     option 'client-path', type: :string, path: true, aliases: :c

--- a/lib/pedicel-pay/client.rb
+++ b/lib/pedicel-pay/client.rb
@@ -39,7 +39,7 @@ module PedicelPay
         decrypt(private_key: key, certificate: certificate, ca_certificate_pem: ca_certificate_pem, now: now)
     end
 
-    def symmetric_key(token,foo)
+    def symmetric_key(token)
       Pedicel::EC.
         new(token).
         symmetric_key(private_key: key, certificate: certificate).

--- a/lib/pedicel-pay/client.rb
+++ b/lib/pedicel-pay/client.rb
@@ -38,5 +38,12 @@ module PedicelPay
         new(token).
         decrypt(private_key: key, certificate: certificate, ca_certificate_pem: ca_certificate_pem, now: now)
     end
+
+    def symmetric_key(token,foo)
+      Pedicel::EC.
+        new(token).
+        symmetric_key(private_key: key, certificate: certificate).
+        unpack('H*')
+    end
   end
 end


### PR DESCRIPTION
It's extracted in hex format because ... well, that's how it's input to our systems.