### PR TITLE
Add decrypt-token-from-symmetric-key

### DIFF
--- a/exe/pedicel-pay
+++ b/exe/pedicel-pay
@@ -165,6 +165,28 @@ module PedicelPay
 
       puts client.decrypt(token, ca_certificate_pem: backend.ca_certificate.to_pem)
     end
+
+    desc 'decrypt-token-from-symmetric-key', 'Decrypt a token using the symmetric key'
+    option 'symmetric-key', type: :string, alias: :k
+    option 'file', type: :string, aliases: :f
+    option 'backend-path', type: :string, path: true, aliases: :b
+    option 'time', type: :string, alias: :t
+
+    def decrypt_token_from_symmetric_key
+      raw_token = options['file'] ? File.read(options['file']) : $stdin.read
+      token = JSON.parse(raw_token)
+
+      params = { symmetric_key: Helper.hex_to_bytestring(options['symmetric-key']) }
+
+      params.merge!(now: Time.parse(options['time'])) if options['time']
+
+      if options['backend-path']
+        backend = Helper.load_backend(options['backend-path'])
+        params.merge!(ca_certificate_pem: backend.ca_certificate.to_pem)
+      end
+
+      puts Pedicel::EC.new(token).decrypt(params)
+    end
   end
 
   class Helper

--- a/lib/pedicel-pay/helper.rb
+++ b/lib/pedicel-pay/helper.rb
@@ -20,6 +20,10 @@ module PedicelPay
       string.unpack('H*').first
     end
 
+    def self.hex_to_bytestring(hex)
+      [hex].pack('H*')
+    end
+
     def self.merchant_id(x)
       case x
       when Client


### PR DESCRIPTION
Can come in handy when testing recurring transactions — for which you should extract the PAN and use "directly" — since https://github.com/clearhaus/applepaymerchant will throw you the token and the symmetric key.