### PR TITLE
Update pedicel dependency and bump version

### DIFF
--- a/lib/pedicel-pay/version.rb
+++ b/lib/pedicel-pay/version.rb
@@ -1,3 +1,3 @@
 module PedicelPay
-  VERSION = '0.0.6'
+  VERSION = '0.0.7'
 end

--- a/pedicel-pay.gemspec
+++ b/pedicel-pay.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler', '~> 2.1.4'
   s.add_development_dependency 'rake', '~> 12.3'
 
-  s.add_runtime_dependency 'pedicel', '~> 1.0.0'
+  s.add_runtime_dependency 'pedicel', '~> 1.1.0'
   s.add_runtime_dependency 'thor', '~> 0.20'
   s.add_runtime_dependency 'openssl', '~> 2.1' # for ruby <= 2.3
 end


### PR DESCRIPTION
Due to https://github.com/clearhaus/pedicel/pull/37 and https://github.com/clearhaus/pedicel/pull/39, i.e. pedicel release v1.1.0.